### PR TITLE
updated login and updated changelog for tag 2.5.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,3 +227,28 @@ Here’s the updated change log for version `2.5.2.3` incorporating your additio
 
 * Fully backward compatible.
 * No changes required in existing configurations.
+
+---
+
+**Tag:** `2.5.2.8`
+**Release Date:** *2025-10-08*
+**Maintainer:** *[Mukul Joshi](mukul.joshi@opstree.com), [GitHub](https://github.com/mukulmj)*
+
+### 🔄 Changes
+
+* **\[NEW]** Added dynamic handling for `SONAR_TESTING_TYPE` to auto-append suffixes (`-it` or `-ut`) to Sonar project keys and names.
+* **\[NEW]** Implemented `INSTRUCTION_TYPE=SONAR_SCAN` handling to execute Sonar-specific Maven commands.
+* **\[ENHANCED]** Added `MAVEN_SONAR_SCAN_INSTRUCTION` resolution inside instruction switch block.
+* **\[IMPROVED]** Ensured sensitive data (`SONAR_TOKEN`) is masked in logs for better security.
+
+### ✅ Impact
+
+* Enables SonarQube scans for both **unit** and **integration** testing pipelines automatically.
+* Prevents accidental exposure of secrets in logs.
+* Expands automation coverage for Maven Sonar scan workflows.
+
+### 📌 Notes
+
+* Backward compatible with all previous tags.
+* No configuration changes required.
+* Works seamlessly with both legacy and new pipeline configurations.

--- a/getDynamicVars.sh
+++ b/getDynamicVars.sh
@@ -92,6 +92,12 @@ function fetch_service_details() {
     MAVEN_OPTIONS=$(echo "$service_data" | jq -r '.MAVEN_OPTIONS // empty')
     export TEST_JAVA_VERSION=$(echo "$service_data" | jq -r '.TEST_JAVA_VERSION')
     export TEST_MAVEN_VERSION=$(echo "$service_data" | jq -r '.TEST_MAVEN_VERSION')
+    export MAVEN_SONAR_SCAN_INSTRUCTION=$(echo "$service_data" | jq -r '.MAVEN_SONAR_SCAN_INSTRUCTION')
+    export SONAR_URL=$(echo "$service_data" | jq -r '.SONAR_URL')
+    export ENCRYPTED_SONAR_TOKEN=$(echo "$service_data" | jq -r '.ENCRYPTED_SONAR_TOKEN')
+
+    # Decrypt the token using the getDecryptedCredential function
+    SONAR_TOKEN=$(getDecryptedCredential "$FERNET_KEY" "$ENCRYPTED_SONAR_TOKEN")
 
     # Override versions if INSTRUCTION_TYPE=TEST
     if [[ "$INSTRUCTION_TYPE" == "TEST" ]]; then


### PR DESCRIPTION
**Tag:** `2.5.2.8`
**Release Date:** *2025-10-08*
**Maintainer:** *[Mukul Joshi](mukul.joshi@opstree.com), [GitHub](https://github.com/mukulmj)*

### 🔄 Changes

* **\[NEW]** Added dynamic handling for `SONAR_TESTING_TYPE` to auto-append suffixes (`-it` or `-ut`) to Sonar project keys and names.
* **\[NEW]** Implemented `INSTRUCTION_TYPE=SONAR_SCAN` handling to execute Sonar-specific Maven commands.
* **\[ENHANCED]** Added `MAVEN_SONAR_SCAN_INSTRUCTION` resolution inside instruction switch block.
* **\[IMPROVED]** Ensured sensitive data (`SONAR_TOKEN`) is masked in logs for better security.

### ✅ Impact

* Enables SonarQube scans for both **unit** and **integration** testing pipelines automatically.
* Prevents accidental exposure of secrets in logs.
* Expands automation coverage for Maven Sonar scan workflows.

### 📌 Notes

* Backward compatible with all previous tags.
* No configuration changes required.
* Works seamlessly with both legacy and new pipeline configurations.
